### PR TITLE
Coerce default value for boolean fields to boolean type

### DIFF
--- a/lib/databasedotcom/sobject/sobject.rb
+++ b/lib/databasedotcom/sobject/sobject.rb
@@ -17,7 +17,8 @@ module Databasedotcom
           if field['type'] =~ /(picklist|multipicklist)/ && picklist_option = field['picklistValues'].find { |p| p['defaultValue'] }
             self.send("#{field["name"]}=", picklist_option["value"])
           elsif field['type'] =~ /boolean/
-            self.send("#{field["name"]}=", field["defaultValue"])
+            # Coerce default value to boolean, since it may be nil and nil is invalid type
+            self.send("#{field["name"]}=", !!field["defaultValue"])
           else
             self.send("#{field["name"]}=", field["defaultValueFormula"])
           end
@@ -32,7 +33,7 @@ module Databasedotcom
           hash
         end
       end
-      
+
       # Set attributes of this object, from a hash, in bulk
       def attributes=(attrs)
         attrs.each do |key, value|
@@ -104,8 +105,8 @@ module Databasedotcom
         selection_attr = self.Id.nil? ? "createable" : "updateable"
         self.class.description["fields"].select { |f| f[selection_attr] }.collect { |f| f["name"] }.each { |attr| attr_hash[attr] = self.send(attr) }
 
-        # allow fields to be removed on a case by case basis as some data is not allowed to be saved 
-        # (e.g. Name field on Account with record type of Person Account) despite the API listing 
+        # allow fields to be removed on a case by case basis as some data is not allowed to be saved
+        # (e.g. Name field on Account with record type of Person Account) despite the API listing
         # some fields as editable
         if options[:exclusions] and options[:exclusions].respond_to?(:include?) then
           attr_hash.delete_if { |key, value| options[:exclusions].include?(key.to_s) }

--- a/spec/lib/sobject/sobject_spec.rb
+++ b/spec/lib/sobject/sobject_spec.rb
@@ -51,8 +51,8 @@ describe Databasedotcom::Sobject::Sobject do
                 @sobject.send(f['name'].to_sym).should == picklist_option['value']
               end
             elsif f['type'] =~ /boolean/
-              it "sets #{f['name']} to #{f['defaultValue']}" do
-                @sobject.send(f['name'].to_sym).should == f['defaultValue']
+              it "sets #{f['name']} to boolean #{f['defaultValue']}" do
+                @sobject.send(f['name'].to_sym).should == !!f['defaultValue']
               end
             else
               it "sets #{f['name']} to #{f['defaultValueFormula'] ? f['defaultValueFormula'] : 'nil'}" do
@@ -582,18 +582,18 @@ describe Databasedotcom::Sobject::Sobject do
             attrs.include?("OwnerId").should be_truthy
             @obj_double
           end
-          
+
           @obj.save(:exclusions => ["Name"])
         end
-        
+
         it "remove any listed fields from the attributes on update" do
           @obj.Id = "foo"
-          
+
           @client.should_receive(:update) do |clazz, id, attrs|
             attrs.include?("Name").should be_falsey
             attrs.include?("OwnerId").should be_truthy
           end
-          
+
           result = @obj.save(:exclusions => ["Name"])
         end
       end


### PR DESCRIPTION
This was copied from https://github.com/heroku/databasedotcom/pull/140/files. 

This change should solve the bugs that arise whenever someone adds a custom checkbox field to SFDC. See https://github.com/heroku/databasedotcom/issues/87 and https://github.com/heroku/databasedotcom/issues/119 and https://github.com/heroku/databasedotcom/issues/132 for context. After this is merged, I will point our gemfile to use our custom fork of `databasedotcom`. 

I decided to fork the repo because the original repo isn't really maintained anymore, and it looks like a previous attempt to get this change into that repo failed due to inactivity. At some point we may need to migrate to a gem that is more maintained, though the alternative, `restforce` doesn't seem to be well maintained either. Luckily, the SFDC API doesn't change much and it will likely be years before they force a change on us that is backwards incompatible with our current API.

@abezzub Can you review?
